### PR TITLE
HOTFIX: Restore can-code.dev domain routing

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+can-code.dev


### PR DESCRIPTION
## Summary
- Fixes GitHub Pages 404 error for can-code.dev custom domain
- Adds missing CNAME file required for GitHub Pages custom domain routing

## Problem
The can-code.dev website was showing "404 there isn't a github pages site here" because:
- GitHub Pages is correctly configured to deploy from main branch
- The main branch was missing the CNAME file for custom domain routing
- Previous production PR (#1) was closed instead of merged

## Solution
Add the CNAME file containing "can-code.dev" to enable GitHub Pages custom domain routing.

## Critical Fix
This is a hotfix to restore website functionality. The can-code.dev website will be accessible immediately after this PR is merged.

🤖 Generated with [Claude Code](https://claude.ai/code)